### PR TITLE
interactive_script: Run install script with --no-dist-upgrade

### DIFF
--- a/marketplace_docs/templates/Fabric/interactive_script.sh
+++ b/marketplace_docs/templates/Fabric/interactive_script.sh
@@ -34,7 +34,7 @@ EOM
 sudo service nginx stop
 
 array=(./zulip-server-*)
-"${array[0]}"/scripts/setup/install --certbot --email="$email" --hostname="$hostname"
+"${array[0]}"/scripts/setup/install --certbot --email="$email" --hostname="$hostname" --no-dist-upgrade
 if [ "$?" = 1 ]; then
    echo "For troubleshooting see https://zulip.readthedocs.io/en/stable/production/troubleshooting.html."
    echo -e "\n"


### PR DESCRIPTION
@timabbott So currently fabric is obtaining the Zulip production tar file from https://www.zulip.org/dist/releases/zulip-server-latest.tar.gz.

https://github.com/zulip/marketplace-partners/blob/87e1a2b0c89e7cf9d69390b85be6975d698a6116/marketplace_docs/templates/Fabric/scripts/01-initial-setup#L16

`scripts/lib/install` script in tar file don't yet have the `--no-dist-upgrade` option(https://github.com/zulip/zulip/pull/12495/). What should be done to mitigate this issue? Should I do an installation from git? I can also manually change content of `scripts/lib/install` to reflect changes of https://github.com/zulip/zulip/pull/12495/ after fabric is done with droplet setup and then rerun only `clean_up` function via fabric. Not a super clean way but it should work.
