### PR TITLE
initial setup: Use -f flag while deleting motds

### DIFF
--- a/marketplace_docs/templates/Fabric/scripts/01-initial-setup
+++ b/marketplace_docs/templates/Fabric/scripts/01-initial-setup
@@ -22,6 +22,6 @@ array=(./zulip-server-*)
 rm -f /etc/zulip/zulip-secrets.conf /etc/zulip/settings.py
 
 # Remove unnessary messages set by Ubuntu that appears during user login.
- rm /etc/update-motd.d/00-header
- rm /etc/update-motd.d/10-help-text
- rm /etc/update-motd.d/51-cloudguest
+ rm -f /etc/update-motd.d/00-header
+ rm -f /etc/update-motd.d/10-help-text
+ rm -f /etc/update-motd.d/51-cloudguest


### PR DESCRIPTION
When I ran build_image itgot cancelled at end because 51-cloudguest was missing in the droplet. So adding -f to rm command to make sure that the exit status is not modfied in case one of the motds don't exit.