### PR TITLE
Don't run apt-daily timers immedeatly after the boot

### DIFF
--- a/marketplace_docs/templates/Fabric/interactive_script.sh
+++ b/marketplace_docs/templates/Fabric/interactive_script.sh
@@ -43,4 +43,6 @@ if [ "$?" = 1 ]; then
 else
    cp -f /etc/skel/.zulip_bashrc /root/.bashrc
    touch /opt/zulip/.configured
+   # Re-enable the systemd job we disabled in image creation.
+   systemctl enable --quiet apt-daily.timer apt-daily-upgrade.timer
 fi

--- a/marketplace_docs/templates/Fabric/scripts/01-initial-setup
+++ b/marketplace_docs/templates/Fabric/scripts/01-initial-setup
@@ -25,3 +25,13 @@ rm -f /etc/zulip/zulip-secrets.conf /etc/zulip/settings.py
  rm -f /etc/update-motd.d/00-header
  rm -f /etc/update-motd.d/10-help-text
  rm -f /etc/update-motd.d/51-cloudguest
+
+# The default Ubuntu behavior of the apt-daily.timer systemd job
+# results in `apt update` running immediately on boot if it's been
+# more than a day since the image was generated.  This can end up
+# conflicting with the other `apt` invocations run by the Zulip
+# interactive installer.  So we disabled it here and then re-enable it
+# once interactive_script.sh completes successfully.
+#
+# For more details see https://chat.zulip.org/#narrow/stream/3-backend/topic/apt-daily
+systemctl disable apt-daily.timer apt-daily-upgrade.timer


### PR DESCRIPTION
https://askubuntu.com/questions/800479/ubuntu-16-04-slow-boot-apt-daily-service

See https://chat.zulip.org/#narrow/stream/3-backend/topic/apt-daily for more details