### PR TITLE
Uninstall droplet-agent during cleanup.

### DIFF
--- a/marketplace_docs/templates/Fabric/fabfile.py
+++ b/marketplace_docs/templates/Fabric/fabfile.py
@@ -26,6 +26,9 @@ def clean_up():
     run("rm -rf /var/lib/cloud/instances/*")
     run("rm -rf /var/lib/cloud/instance")
     run(": > /var/mail/$USER")
+    # droplet-agent nedes to be removed to avoid "DigitalOcean directory detected." test failure.
+    run("apt-get purge droplet-agent -y")
+
     puts("Removing keys...")
     run("rm -f /root/.ssh/authorized_keys /etc/ssh/*key*")
     run("dd if=/dev/zero of=/zerofile; sync; rm /zerofile; sync")


### PR DESCRIPTION
This is now a required cleanup step for image check to pass.